### PR TITLE
Remove --server :8080 from sabnzbd config.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ VOLUME ["/config","/data"]
 
 EXPOSE 8080 9090
 
-CMD ["/usr/bin/sabnzbdplus","--config-file","/config","--server",":8080","--console"]
+CMD ["/usr/bin/sabnzbdplus","--config-file","/config","--console"]


### PR DESCRIPTION
Otherwise, sabnzbd will overwrite any existing config every time it
starts up, preventing users from rebinding sabnzbd to any other ports,
or enabling SSL. Port 8080 is the default anyway, so this should have no
change on existing users of port 8080.