### PR TITLE
Remove outdated themes from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Tim Haak <tim@haak.co>
 
 RUN add-apt-repository -y  ppa:jcfp/ppa && \
     apt-get -q update && \
-    apt-get install -qy --force-yes  sabnzbdplus sabnzbdplus-theme-classic sabnzbdplus-theme-mobile sabnzbdplus-theme-plush \
+    apt-get install -qy --force-yes sabnzbdplus \
     par2 python-yenc unzip unrar && \
     apt-get -y autoremove && \
     apt-get -y clean && \


### PR DESCRIPTION
Sab appears to have updated to v1.1.0~rc1.

The existing classic, mobile and plush themes conflict with this version when installing via apt-get, causing the docker build command to fail.
Removing them from the Dockerfile fixes this, and appears to have no adverse effects.
(see issue for screenshot)