### PR TITLE
Removed Server IP/Port to allow container to  Work on Rancher Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,4 @@ VOLUME ["/datadir", "/download"]
 
 WORKDIR /sabnzbd
 
-CMD su -pc "./SABnzbd.py -b 0 -f /datadir/config.ini -s 0.0.0.0:8080"
+CMD su -pc "./SABnzbd.py -b 0 -f /datadir/config.ini"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ docker build -t sabnzbd .
 ```
 docker run -d \
   -h *your_host_name* \
-  -v /*your_config_location*:/config \
+  -v /*your_config_location*:/datadir \
   -v /*your_videos_location*:/data \
   -p 8080:8080 \
   --restart=always sabnzbd


### PR DESCRIPTION
Updated  image to allow to work on Rancher Server 
Having the server IP:Port setting prevents the image from being accessible on rancher (Due to rancher having an internal network setup)