### PR TITLE
fixes ssl import error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,6 @@ RUN buildDeps="gcc g++ git mercurial make automake autoconf python-dev openssl-d
 && python setup.py build \
 && python setup.py install \
 && cd / \
-&& rm -rf /yenc \
-&& apk del $buildDeps \
 && rm -rf \
     /var/cache/apk \
     /par2cmdline \


### PR DESCRIPTION
With the current Dockerfile, Sabnzbd doesn't have ssl (when you go into the config). After a bit of debugging it's because

```python
from OpenSSL import SSL
...
ImportError: No module named pkg_resources
```

because `pkg_resources` gets deleted during the cleanup.

Delete the following two lines

-&& rm -rf /yenc \                         # equivalent line is below
-&& apk del $buildDeps \             # deletes a package that provides pkg_resources

This is a pretty big hammer so I don't expect you to just merge it, but it does fix the problem, and at the moment that's all I need.