### PR TITLE
Empty apk cache don't delete folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN buildDeps="gcc g++ git mercurial make automake autoconf python-dev openssl-d
 && rm -rf /yenc \
 && apk del $buildDeps \
 && rm -rf \
-    /var/cache/apk \
+    /var/cache/apk/* \
     /par2cmdline \
     /yenc \
     /sabnzbd/.git \


### PR DESCRIPTION
When debuging it can be useful to log in to a running container and install
additional application. Without this directory you can't download the package
list though and you have to recreate it first. Since it doesn't cost anything
to keep the directory we can just remove all the files in it.